### PR TITLE
Palette area

### DIFF
--- a/src/Components/ColorSwatch/ColorSwatch.js
+++ b/src/Components/ColorSwatch/ColorSwatch.js
@@ -1,9 +1,13 @@
 import React from 'react';
 
-const ColorSwatch = () => {
+const ColorSwatch = ({ hex, isLocked }) => {
+  const lockIcon = isLocked ? <p>Locked</p> : <p>Unlocked</p>;
   return(
-    <div>
-      ColorSwatch!
+    <div className='ColorSwatch--div'>
+      <div classNAme='ColorSwatch--div--color' style={{backgroundColor: hex}}>
+      </div>
+      {lockIcon}
+      <p>{hex.toUpperCase()}</p>
     </div>
   )
 };

--- a/src/Components/ColorSwatch/ColorSwatch.test.js
+++ b/src/Components/ColorSwatch/ColorSwatch.test.js
@@ -1,15 +1,22 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ColorSwatch from './ColorSwatch';
+import * as mockData from '../../mockData';
 
 describe('ColorSwatch', () => {
   let wrapper;
-
+  const mockColor = mockData.mockPalette[0];
+  const mockLockedColor = {...mockColor, isLocked: true };
   beforeEach(() => {
-    wrapper = shallow(<ColorSwatch/>);
+    wrapper = shallow(<ColorSwatch {...mockColor}/>);
   });
 
-  it('should match the snapshot', () => {
+  it('should match the snapshot when a color is unlocked', () => {
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should match the snapshot when a color is locked', () => {
+    wrapper = shallow(<ColorSwatch {...mockLockedColor} />);
+    expect(wrapper).toMatchSnapshot();
+  })
 });

--- a/src/Components/ColorSwatch/__snapshots__/ColorSwatch.test.js.snap
+++ b/src/Components/ColorSwatch/__snapshots__/ColorSwatch.test.js.snap
@@ -1,7 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ColorSwatch should match the snapshot 1`] = `
-<div>
-  ColorSwatch!
+exports[`ColorSwatch should match the snapshot when a color is locked 1`] = `
+<div
+  className="ColorSwatch--div"
+>
+  <div
+    classNAme="ColorSwatch--div--color"
+    style={
+      Object {
+        "backgroundColor": "#FCB97D",
+      }
+    }
+  />
+  <p>
+    Locked
+  </p>
+  <p>
+    #FCB97D
+  </p>
+</div>
+`;
+
+exports[`ColorSwatch should match the snapshot when a color is unlocked 1`] = `
+<div
+  className="ColorSwatch--div"
+>
+  <div
+    classNAme="ColorSwatch--div--color"
+    style={
+      Object {
+        "backgroundColor": "#FCB97D",
+      }
+    }
+  />
+  <p>
+    Unlocked
+  </p>
+  <p>
+    #FCB97D
+  </p>
 </div>
 `;

--- a/src/Containers/App/__snapshots__/App.test.js.snap
+++ b/src/Containers/App/__snapshots__/App.test.js.snap
@@ -10,7 +10,7 @@ exports[`App App component should match the snapshot 1`] = `
   <button>
     Generate A Palette
   </button>
-  <PaletteArea />
+  <Connect(PaletteArea) />
   <PaletteForm />
   <Sidebar />
   <Error />

--- a/src/Containers/PaletteArea/PaletteArea.js
+++ b/src/Containers/PaletteArea/PaletteArea.js
@@ -1,13 +1,18 @@
 import React, { Component } from 'react';
 import ColorSwatch from '../../Components/ColorSwatch/ColorSwatch';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 export class PaletteArea extends Component{
+
   render() {
+    const colors = this.props.currentPalette.map(color => {
+      return <ColorSwatch {...color} key={color.hex}/>
+    });
+
     return (
       <div>
-        PaletteArea!!!
-        <ColorSwatch/>
+        {colors}
       </div>
     )
   }
@@ -19,3 +24,6 @@ const mapStateToProps = (state) => ({
 
 export default connect(mapStateToProps)(PaletteArea);
 
+PaletteArea.propTypes = {
+  currentPalette: PropTypes.array
+}

--- a/src/Containers/PaletteArea/PaletteArea.js
+++ b/src/Containers/PaletteArea/PaletteArea.js
@@ -18,7 +18,7 @@ export class PaletteArea extends Component{
   }
 }
 
-const mapStateToProps = (state) => ({
+export const mapStateToProps = (state) => ({
   currentPalette: state.currentPalette
 });
 

--- a/src/Containers/PaletteArea/PaletteArea.js
+++ b/src/Containers/PaletteArea/PaletteArea.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import ColorSwatch from '../../Components/ColorSwatch/ColorSwatch';
+import { connect } from 'react-redux';
 
 export class PaletteArea extends Component{
   render() {
@@ -12,4 +13,9 @@ export class PaletteArea extends Component{
   }
 }
 
-export default PaletteArea;
+const mapStateToProps = (state) => ({
+  currentPalette: state.currentPalette
+});
+
+export default connect(mapStateToProps)(PaletteArea);
+

--- a/src/Containers/PaletteArea/PaletteArea.test.js
+++ b/src/Containers/PaletteArea/PaletteArea.test.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { PaletteArea } from './PaletteArea';
+import * as mockData from '../../mockData';
 
 describe('PaletteArea', () => {
   describe('PaletteArea component', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(<PaletteArea/>);
+      wrapper = shallow(<PaletteArea currentPalette={mockData.mockPalette}/>);
     });
 
     it('should match the snapshot', () => {

--- a/src/Containers/PaletteArea/PaletteArea.test.js
+++ b/src/Containers/PaletteArea/PaletteArea.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { PaletteArea } from './PaletteArea';
+import { PaletteArea, mapStateToProps } from './PaletteArea';
 import * as mockData from '../../mockData';
 
 describe('PaletteArea', () => {
@@ -13,6 +13,21 @@ describe('PaletteArea', () => {
 
     it('should match the snapshot', () => {
       expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    it('should return an object with currentPalette', () => {
+      const mockState = {
+        error: '',
+        isLoading: false,
+        currentPalette: mockData.mockPalette
+      }
+      const expected = {
+        currentPalette: mockData.mockPalette
+      }
+      const mappedProps = mapStateToProps(mockState);
+      expect(mappedProps).toEqual(expected);
     });
   });
 });

--- a/src/Containers/PaletteArea/__snapshots__/PaletteArea.test.js.snap
+++ b/src/Containers/PaletteArea/__snapshots__/PaletteArea.test.js.snap
@@ -2,7 +2,30 @@
 
 exports[`PaletteArea PaletteArea component should match the snapshot 1`] = `
 <div>
-  PaletteArea!!!
-  <ColorSwatch />
+  <ColorSwatch
+    hex="#FCB97D"
+    isLocked={false}
+    key="#FCB97D"
+  />
+  <ColorSwatch
+    hex="#EDD892"
+    isLocked={false}
+    key="#EDD892"
+  />
+  <ColorSwatch
+    hex="#C6B89E"
+    isLocked={false}
+    key="#C6B89E"
+  />
+  <ColorSwatch
+    hex="#B5B8A3"
+    isLocked={false}
+    key="#B5B8A3"
+  />
+  <ColorSwatch
+    hex="#AABA9E"
+    isLocked={false}
+    key="#AABA9E"
+  />
 </div>
 `;


### PR DESCRIPTION
# Description

- Connects PaletteArea to redux store and maps over currentPalette to display ColorSwatch(s) for each color
- Updates App snapshot displaying Connected PaletteArea
- Updates PaletteArea snapshot and test and adds test for mapStateToProps
- Updates ColorSwatch to display the text of the hex color passed down as props and use it dynamically update the inline style - background color
- Adds tests and snapshots for ColorSwatch when a color is lock and unlocked

List any dependencies that are required for this change:
N/A
Fixes # (issue)
Closes #36 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Where should the reviewer start?:
Start with PaletteArea and test changes
## image or gif (optional):
![Screen Shot 2019-03-25 at 3 13 27 PM](https://user-images.githubusercontent.com/40586291/54954579-933f9700-4f10-11e9-9158-1b33602e52a8.png)

## Additional information for the reviewer:
Although the background color is not visible right now, once we add an scss file for ColorSwatches and set the height of the div where the inline style is set the colors will display