### PR TITLE
Post thunk

### DIFF
--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -28,3 +28,8 @@ export const setCurrentExpandedProject = (id) => ({
   type: 'SET_CURRENT_EXPANDED_PROJECT',
   id
 })
+export const addProject = (name, id) => ({
+  type: 'ADD_PROJECT',
+  name,
+  id
+});

--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -33,3 +33,9 @@ export const addProject = (name, id) => ({
   name,
   id
 });
+
+export const addPaletteToProject = (projectId, palette) => ({
+  type: 'ADD_PALETTE',
+  projectId,
+  palette
+});

--- a/src/Actions/index.test.js
+++ b/src/Actions/index.test.js
@@ -69,4 +69,21 @@ describe('actions', () => {
     const result = actions.addProject(mockName, mockId);
     expect(result).toEqual(expected);
   });
+
+  it('should return an object with ADD_PALETTE a project id and palette', () => {
+    const mockProjectId = 1
+    const paletteToSave = { 
+      name: 'Lavender Shades', 
+      ...mockData.mockPalette, 
+      id: 2, 
+      project_id: mockProjectId
+    };
+    const expected = {
+      type: 'ADD_PALETTE',
+      projectId: mockProjectId,
+      palette: paletteToSave
+    };
+    const result = actions.addPaletteToProject(mockProjectId, paletteToSave);
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Actions/index.test.js
+++ b/src/Actions/index.test.js
@@ -58,4 +58,15 @@ describe('actions', () => {
     const result = actions.setCurrentExpandedProject(1);
     expect(result).toEqual(expected);
   })
+  it('should return an object with ADD_PROJECT a name and id', () => {
+    const mockName = 'Pretty Purples';
+    const mockId = 2;
+    const expected = {
+      type: 'ADD_PROJECT',
+      name: mockName,
+      id: mockId
+    }
+    const result = actions.addProject(mockName, mockId);
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Reducers/ProjectsReducer.js
+++ b/src/Reducers/ProjectsReducer.js
@@ -23,6 +23,18 @@ export const projectsReducer = (state = [], action) => {
         }
       ];
       return projectsWithNewProject
+    case 'ADD_PALETTE':
+      const projectsWithNewPalette = state.map(project => {
+        if(project.id === action.projectId) {
+          const projectWithNewPalette = {
+            ...project,
+            palettes: [...project.palettes, action.palette]
+          }
+          return projectWithNewPalette;
+        }
+        return project;
+      });
+      return projectsWithNewPalette
     default:
       return state
   };

--- a/src/Reducers/ProjectsReducer.js
+++ b/src/Reducers/ProjectsReducer.js
@@ -13,6 +13,16 @@ export const projectsReducer = (state = [], action) => {
         return project
       })
       return updatedProjects
+    case 'ADD_PROJECT':
+      const projectsWithNewProject = [
+        ...state, 
+        {
+          name: action.name,
+          id: action.id,
+          palettes: []
+        }
+      ];
+      return projectsWithNewProject
     default:
       return state
   };

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -21,7 +21,9 @@ describe('projectsReducer', () => {
     const mockPalettes = mockData.mockProjectPalettes;
     const initialState = mockData.mockProjectsWithEmptyPalettes;
     const result = projectsReducer(initialState, actions.addProjectPalettes(mockPalettes, 1));
-    expect(result).toEqual(mockProjects)
+    expect(result).toEqual(mockProjects);
+  });
+  
   it('should add a project', () => {
     const mockName = 'Pretty Purples';
     const mockId = 2;

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -22,5 +22,18 @@ describe('projectsReducer', () => {
     const initialState = mockData.mockProjectsWithEmptyPalettes;
     const result = projectsReducer(initialState, actions.addProjectPalettes(mockPalettes, 1));
     expect(result).toEqual(mockProjects)
+  it('should add a project', () => {
+    const mockName = 'Pretty Purples';
+    const mockId = 2;
+    const initialState = [];
+    const expected = [
+      {
+        name: mockName,
+        id: mockId,
+        palettes: []
+      }
+    ]
+    const result = projectsReducer(initialState, actions.addProject(mockName, mockId));
+    expect(result).toEqual(expected);
   });
 });

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -36,4 +36,23 @@ describe('projectsReducer', () => {
     const result = projectsReducer(initialState, actions.addProject(mockName, mockId));
     expect(result).toEqual(expected);
   });
+
+  it('should add a palette to a project', () => {
+    const mockId = 1;
+    const mockProject = {
+      name: 'Purples',
+      id: mockId,
+      palettes: []
+    }
+    const mockPalette = {
+      name: 'Lavender Shades',
+      ...mockData.mockPalette,
+      id: 2,
+      project_id: mockId
+    }
+    const initialState = [mockProject];
+    const expected = [ {...mockProject, palettes: [ mockPalette ] } ];
+    const result = projectsReducer(initialState, actions.addPaletteToProject(mockId, mockPalette));
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Thunks/__tests__/postProject.js
+++ b/src/Thunks/__tests__/postProject.js
@@ -1,0 +1,51 @@
+import { postProject } from '../postProject';
+import * as actions from '../../Actions';
+import * as utils from '../../Utils/fetch';
+
+describe('postProjects', () => {
+  const mockDispatch = jest.fn();
+  const mockName = 'Lovely Lavenders';
+  const thunk = postProject(mockName);
+  const mockNamingError = 'Project name already exists.';
+  const mockId = 3;
+
+  beforeEach(() => {
+    utils.fetchData = jest.fn().mockImplementation(() => Promise.resolve({ id: mockId}));
+  });
+
+  it('should call dispatch with toggleLoading with true', () => {
+    thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(true));
+  });
+
+  it('should call fetchData with /projects and a project name', async () => {
+    const mockOptions = utils.createOptions('POST', { name: mockName });
+    const mockPath = '/projects';
+    await thunk(mockDispatch);
+    expect(utils.fetchData).toHaveBeenCalledWith(mockPath, mockOptions);
+  });
+
+  it('should call dispatch with toggleLoading with false', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));
+  });
+
+  it('should call dispatch with addProject with a name and id', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.addProject(mockName, mockId));
+  });
+
+  it('should call dispatch with toggleLoading with false if the name already exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockNamingError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));
+  });
+
+
+  it('should call dispatch with setError with a message if the name already exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockNamingError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.setError(mockNamingError));
+  });
+
+});

--- a/src/Thunks/postProject.js
+++ b/src/Thunks/postProject.js
@@ -1,0 +1,18 @@
+import { toggleLoading, setError, addProject } from '../Actions';
+import { fetchData, createOptions } from '../Utils/fetch';
+
+export const postProject = (projectName) => {
+  return async (dispatch) => {
+    const url = '/projects';
+    const options = createOptions('POST', { name: projectName });
+    try {
+      dispatch(toggleLoading(true));
+      const projectId = await fetchData(url, options);
+      dispatch(toggleLoading(false));
+      dispatch(addProject(projectName, projectId.id));
+    } catch(error) {
+      dispatch(toggleLoading(false));
+      dispatch(setError(error.message))
+    }
+  }
+}


### PR DESCRIPTION
# Description
- Adds postProject thunk and associated actions and case for the projectReducer
- Adds tests for the above
- Adds action and case for the projectReducer to add a new palette to an existing project

List any dependencies that are required for this change:
N/A 
Fixes # (issue)
Closes #20 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Where should the reviewer start?:
Start with postProject thunk 
## image or gif (optional):

## Additional information for the reviewer:
Will add postPalette thunk shortly to use the addPalettToProject action