### PR TITLE
Delete thunk

### DIFF
--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -39,3 +39,8 @@ export const addPaletteToProject = (projectId, palette) => ({
   projectId,
   palette
 });
+
+export const deletePalette = (paletteId) => ({
+  type: 'DELETE_PALETTE',
+  paletteId
+});

--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -45,3 +45,8 @@ export const deletePalette = (paletteId, projectId) => ({
   paletteId,
   projectId
 });
+
+export const deleteProject = (projectId) => ({
+  type: 'DELETE_PROJECT',
+  projectId
+});

--- a/src/Actions/index.js
+++ b/src/Actions/index.js
@@ -40,7 +40,8 @@ export const addPaletteToProject = (projectId, palette) => ({
   palette
 });
 
-export const deletePalette = (paletteId) => ({
+export const deletePalette = (paletteId, projectId) => ({
   type: 'DELETE_PALETTE',
-  paletteId
+  paletteId,
+  projectId
 });

--- a/src/Actions/index.test.js
+++ b/src/Actions/index.test.js
@@ -98,4 +98,14 @@ describe('actions', () => {
     const result = actions.deletePalette(mockPaletteId, mockProjectId);
     expect(result).toEqual(expected);
   });
+
+  it('should return an oject with DELETE_PROJECT and a projectId', () => {
+    const mockId = 5;
+    const expected = {
+      type: 'DELETE_PROJECT',
+      projectId: mockId
+    };
+    const result = actions.deleteProject(mockId);
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Actions/index.test.js
+++ b/src/Actions/index.test.js
@@ -89,11 +89,13 @@ describe('actions', () => {
 
   it('should return an objet with DELETE_PALETTE and a palette id', () => {
     const mockPaletteId = 4;
+    const mockProjectId = 3;
     const expected = {
       type: 'DELETE_PALETTE',
-      paletteId: mockPaletteId
+      paletteId: mockPaletteId,
+      projectId: mockProjectId
     };
-    const result = actions.deletePalette(mockPaletteId);
+    const result = actions.deletePalette(mockPaletteId, mockProjectId);
     expect(result).toEqual(expected);
-  })
+  });
 });

--- a/src/Actions/index.test.js
+++ b/src/Actions/index.test.js
@@ -86,4 +86,14 @@ describe('actions', () => {
     const result = actions.addPaletteToProject(mockProjectId, paletteToSave);
     expect(result).toEqual(expected);
   });
+
+  it('should return an objet with DELETE_PALETTE and a palette id', () => {
+    const mockPaletteId = 4;
+    const expected = {
+      type: 'DELETE_PALETTE',
+      paletteId: mockPaletteId
+    };
+    const result = actions.deletePalette(mockPaletteId);
+    expect(result).toEqual(expected);
+  })
 });

--- a/src/Components/ColorSwatch/__snapshots__/ColorSwatch.test.js.snap
+++ b/src/Components/ColorSwatch/__snapshots__/ColorSwatch.test.js.snap
@@ -5,7 +5,7 @@ exports[`ColorSwatch should match the snapshot when a color is locked 1`] = `
   className="ColorSwatch--div"
 >
   <div
-    classNAme="ColorSwatch--div--color"
+    className="ColorSwatch--div--color"
     style={
       Object {
         "backgroundColor": "#FCB97D",
@@ -26,7 +26,7 @@ exports[`ColorSwatch should match the snapshot when a color is unlocked 1`] = `
   className="ColorSwatch--div"
 >
   <div
-    classNAme="ColorSwatch--div--color"
+    className="ColorSwatch--div--color"
     style={
       Object {
         "backgroundColor": "#FCB97D",

--- a/src/Containers/App/__snapshots__/App.test.js.snap
+++ b/src/Containers/App/__snapshots__/App.test.js.snap
@@ -4,16 +4,18 @@ exports[`App App component should match the snapshot 1`] = `
 <div
   className="App"
 >
-  <h1>
-    Colorations
-  </h1>
-  <button>
-    Generate A Palette
-  </button>
+  <div
+    className="App--header"
+  >
+    <h1>
+      Colorations
+    </h1>
+    <button>
+      Generate A Palette
+    </button>
+  </div>
   <Connect(PaletteArea) />
   <PaletteForm />
   <Sidebar />
-  <Error />
-  <Loading />
 </div>
 `;

--- a/src/Containers/PaletteArea/__snapshots__/PaletteArea.test.js.snap
+++ b/src/Containers/PaletteArea/__snapshots__/PaletteArea.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PaletteArea PaletteArea component should match the snapshot 1`] = `
-<div>
+<div
+  className="PaletteArea--div"
+>
   <ColorSwatch
     hex="#FCB97D"
     isLocked={false}

--- a/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
+++ b/src/Containers/PaletteForm/__snapshots__/PaletteForm.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PaletteForm PaletteForm component should match the snapshot 1`] = `
-<form>
+<form
+  className="PaletteForm--form"
+>
   <select>
     <option>
       Choose a Project

--- a/src/Containers/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/src/Containers/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sidebar Sidebar component should match the snapshit 1`] = `
-<div>
+<div
+  className="Sidebar--div"
+>
   <h2>
     My Projects
   </h2>

--- a/src/Reducers/ProjectsReducer.js
+++ b/src/Reducers/ProjectsReducer.js
@@ -46,6 +46,11 @@ export const projectsReducer = (state = [], action) => {
         return project;
       });
       return projectsWithPaletteRemoved
+    case 'DELETE_PROJECT':
+      const projectsFiltered = state.filter(project => {
+        return project.id !== action.projectId;
+      });
+      return projectsFiltered;
     default:
       return state
   };

--- a/src/Reducers/ProjectsReducer.js
+++ b/src/Reducers/ProjectsReducer.js
@@ -37,10 +37,13 @@ export const projectsReducer = (state = [], action) => {
       return projectsWithNewPalette
     case 'DELETE_PALETTE':
       const projectsWithPaletteRemoved = state.map(project => {
-        const updatedPalettes = project.palettes.filter(palette => {
-          return palette.id !== action.paletteId;
-        });
-        return { ...project, palettes: updatedPalettes }
+        if(project.id === action.projectId) {
+          const updatedPalettes = project.palettes.filter(palette => {
+            return palette.id !== action.paletteId;
+          });
+          return { ...project, palettes: updatedPalettes };
+        }
+        return project;
       });
       return projectsWithPaletteRemoved
     default:

--- a/src/Reducers/ProjectsReducer.js
+++ b/src/Reducers/ProjectsReducer.js
@@ -35,6 +35,14 @@ export const projectsReducer = (state = [], action) => {
         return project;
       });
       return projectsWithNewPalette
+    case 'DELETE_PALETTE':
+      const projectsWithPaletteRemoved = state.map(project => {
+        const updatedPalettes = project.palettes.filter(palette => {
+          return palette.id !== action.paletteId;
+        });
+        return { ...project, palettes: updatedPalettes }
+      });
+      return projectsWithPaletteRemoved
     default:
       return state
   };

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -61,8 +61,9 @@ describe('projectsReducer', () => {
   it('should delete a specific palette', () => {
     const initialState = mockData.mockProjectsWithFullPalettes;
     const mockPaletteIdToDelete = 1;
+    const mockProjectId = 1;
     const expected = mockData.mockProjectsAfterDelete;
-    const result = projectsReducer(initialState, actions.deletePalette(mockPaletteIdToDelete));
+    const result = projectsReducer(initialState, actions.deletePalette(mockPaletteIdToDelete, mockProjectId));
     expect(result).toEqual(expected);
   });
 });

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -57,4 +57,12 @@ describe('projectsReducer', () => {
     const result = projectsReducer(initialState, actions.addPaletteToProject(mockId, mockPalette));
     expect(result).toEqual(expected);
   });
+
+  it('should delete a specific palette', () => {
+    const initialState = mockData.mockProjectsWithFullPalettes;
+    const mockPaletteIdToDelete = 1;
+    const expected = mockData.mockProjectsAfterDelete;
+    const result = projectsReducer(initialState, actions.deletePalette(mockPaletteIdToDelete));
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Reducers/__tests__/ProjectsReducer.js
+++ b/src/Reducers/__tests__/ProjectsReducer.js
@@ -66,4 +66,12 @@ describe('projectsReducer', () => {
     const result = projectsReducer(initialState, actions.deletePalette(mockPaletteIdToDelete, mockProjectId));
     expect(result).toEqual(expected);
   });
+
+  it('should delete a specific project', () => {
+    const initialState = mockData.mockProjects;
+    const mockProjectIdToDelete = 2;
+    const expected = mockData.mockProjectsAfterProjectDelete;
+    const result = projectsReducer(initialState, actions.deleteProject(mockProjectIdToDelete));
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/Thunks/__tests__/deletePaletteThunk.js
+++ b/src/Thunks/__tests__/deletePaletteThunk.js
@@ -1,0 +1,49 @@
+import { deletePaletteThunk } from '../deletePaletteThunk';
+import * as actions from '../../Actions';
+import * as utils from '../../Utils/fetch';
+
+describe('deletePaletteThunk', () => {
+  const mockDispatch = jest.fn();
+  const mockId = 2
+  const thunk = deletePaletteThunk(mockId);
+  const mockIdError = 'No palette exists with id: 0';
+
+  beforeEach(() => {
+    utils.fetchData = jest.fn().mockImplementation(() => Promise.resolve({ status: 204 }));
+  });
+
+  it('should call dispatch with toggleLoading with true', () => {
+    thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(true));
+  });
+
+  it('should call fetchData with /palettes/:id', async () => {
+    const mockOptions = utils.createOptions('DELETE');
+    const mockPath = `/palettes/${mockId}`;
+    await thunk(mockDispatch);
+    expect(utils.fetchData).toHaveBeenCalledWith(mockPath, mockOptions);
+  });
+
+  it('should call dispatch with toggleLoading with false', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));
+  });
+
+  it('should call dispatch with deletePalette with an id', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.deletePalette(mockId));
+  });
+
+  it('should call dispatch with toggleLoading with false if no palette with id exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockIdError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));
+  });
+
+  it('should call dispatch with set error with a message if no palette with id exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockIdError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.setError(mockIdError));
+  });
+
+});

--- a/src/Thunks/__tests__/deletePaletteThunk.js
+++ b/src/Thunks/__tests__/deletePaletteThunk.js
@@ -4,8 +4,9 @@ import * as utils from '../../Utils/fetch';
 
 describe('deletePaletteThunk', () => {
   const mockDispatch = jest.fn();
-  const mockId = 2
-  const thunk = deletePaletteThunk(mockId);
+  const mockPaletteId = 2;
+  const mockProjectId = 1;
+  const thunk = deletePaletteThunk(mockPaletteId, mockProjectId);
   const mockIdError = 'No palette exists with id: 0';
 
   beforeEach(() => {
@@ -19,7 +20,7 @@ describe('deletePaletteThunk', () => {
 
   it('should call fetchData with /palettes/:id', async () => {
     const mockOptions = utils.createOptions('DELETE');
-    const mockPath = `/palettes/${mockId}`;
+    const mockPath = `/palettes/${mockPaletteId}`;
     await thunk(mockDispatch);
     expect(utils.fetchData).toHaveBeenCalledWith(mockPath, mockOptions);
   });
@@ -31,7 +32,7 @@ describe('deletePaletteThunk', () => {
 
   it('should call dispatch with deletePalette with an id', async () => {
     await thunk(mockDispatch);
-    expect(mockDispatch).toHaveBeenCalledWith(actions.deletePalette(mockId));
+    expect(mockDispatch).toHaveBeenCalledWith(actions.deletePalette(mockPaletteId, mockProjectId));
   });
 
   it('should call dispatch with toggleLoading with false if no palette with id exists', async () => {

--- a/src/Thunks/__tests__/deletePaletteThunk.js
+++ b/src/Thunks/__tests__/deletePaletteThunk.js
@@ -8,13 +8,14 @@ describe('deletePaletteThunk', () => {
   const mockProjectId = 1;
   const thunk = deletePaletteThunk(mockPaletteId, mockProjectId);
   const mockIdError = 'No palette exists with id: 0';
+  utils.fetchData = jest.fn();
 
   beforeEach(() => {
     utils.fetchData = jest.fn().mockImplementation(() => Promise.resolve({ status: 204 }));
   });
 
-  it('should call dispatch with toggleLoading with true', () => {
-    thunk(mockDispatch);
+  it('should call dispatch with toggleLoading with true', async () => {
+    await thunk(mockDispatch);
     expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(true));
   });
 

--- a/src/Thunks/__tests__/deleteProjectThunk.js
+++ b/src/Thunks/__tests__/deleteProjectThunk.js
@@ -1,0 +1,49 @@
+import { deleteProjectThunk } from '../deleteProjectThunk';
+import * as actions from '../../Actions';
+import * as utils from '../../Utils/fetch';
+
+describe('deleteProjectThunk', () => {
+  const mockDispatch = jest.fn();
+  const mockProjId = 5;
+  const mockError = `No project exists with id: ${mockProjId}`;
+  const thunk = deleteProjectThunk(mockProjId);
+  utils.fetchData = jest.fn();
+
+  beforeEach(() => {
+    utils.fetchData = jest.fn().mockImplementation(() => Promise.resolve({ status: 204 }));
+  });
+
+  it('should call dispatch with toggleLoading true', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(true));
+  });
+
+  it('should call fetchData with /palettes/:id', async () => {
+    const mockOptions = utils.createOptions('DELETE');
+    const mockPath = `/projects/${mockProjId}`;
+    await thunk(mockDispatch);
+    expect(utils.fetchData).toHaveBeenCalledWith(mockPath, mockOptions);
+  });
+
+  it('should call dispatch with toggleLoading with false', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));
+  });
+
+  it('should call dispatch with deleteProject and an id', async () => {
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.deleteProject(mockProjId));
+  });
+
+  it('should call dispatch with toggleLoading and false if no project with id exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.toggleLoading(false));    
+  });
+
+  it('should call dispatch with setError and a message if no projects with id exists', async () => {
+    utils.fetchData = jest.fn().mockImplementation(() => { throw new Error(mockError) });
+    await thunk(mockDispatch);
+    expect(mockDispatch).toHaveBeenCalledWith(actions.setError(mockError));
+  });
+});

--- a/src/Thunks/deletePaletteThunk.js
+++ b/src/Thunks/deletePaletteThunk.js
@@ -1,7 +1,7 @@
 import { toggleLoading, setError, deletePalette } from '../Actions';
 import { fetchData, createOptions } from '../Utils/fetch';
 
-export const deletePaletteThunk = (paletteId) => {
+export const deletePaletteThunk = (paletteId, projectId) => {
   return async (dispatch) => {
     const url = `/palettes/${paletteId}`;
     const options = createOptions('DELETE');
@@ -9,7 +9,7 @@ export const deletePaletteThunk = (paletteId) => {
       dispatch(toggleLoading(true));
       await fetchData(url, options);
       dispatch(toggleLoading(false));
-      dispatch(deletePalette(paletteId));
+      dispatch(deletePalette(paletteId, projectId));
     } catch(error) {
       dispatch(toggleLoading(false));
       dispatch(setError(error.message));

--- a/src/Thunks/deletePaletteThunk.js
+++ b/src/Thunks/deletePaletteThunk.js
@@ -1,0 +1,18 @@
+import { toggleLoading, setError, deletePalette } from '../Actions';
+import { fetchData, createOptions } from '../Utils/fetch';
+
+export const deletePaletteThunk = (paletteId) => {
+  return async (dispatch) => {
+    const url = `/palettes/${paletteId}`;
+    const options = createOptions('DELETE');
+    try {
+      dispatch(toggleLoading(true));
+      await fetchData(url, options);
+      dispatch(toggleLoading(false));
+      dispatch(deletePalette(paletteId));
+    } catch(error) {
+      dispatch(toggleLoading(false));
+      dispatch(setError(error.message));
+    }
+  }
+}

--- a/src/Thunks/deleteProjectThunk.js
+++ b/src/Thunks/deleteProjectThunk.js
@@ -1,0 +1,18 @@
+import { toggleLoading, setError, deleteProject } from '../Actions';
+import { fetchData, createOptions } from '../Utils/fetch';
+
+export const deleteProjectThunk = (id) => {
+  return async (dispatch) => {
+    const url = `/projects/${id}`;
+    const options = createOptions('DELETE');
+    try {
+      dispatch(toggleLoading(true));
+      await fetchData(url, options);
+      dispatch(toggleLoading(false));
+      dispatch(deleteProject(id));
+    } catch(error) {
+      dispatch(toggleLoading(false));
+      dispatch(setError(error.message));
+    }
+  }
+}

--- a/src/Utils/fetch.js
+++ b/src/Utils/fetch.js
@@ -3,7 +3,7 @@ export const fetchData = async (path, options) => {
     if(response.status >= 300) {
       const error = await response.json()
       throw new Error(error)
-    } else {
+    } else if (response.status !== 204) {
       return await response.json()
     }
 };

--- a/src/Utils/fetch.js
+++ b/src/Utils/fetch.js
@@ -5,6 +5,8 @@ export const fetchData = async (path, options) => {
       throw new Error(error)
     } else if (response.status !== 204) {
       return await response.json()
+    } else {
+      return response.status;
     }
 };
 

--- a/src/Utils/fetch.test.js
+++ b/src/Utils/fetch.test.js
@@ -4,14 +4,23 @@ import * as mockData from '../mockData';
 describe('Utils', () => {
   describe('fetchData', () => {
     const mockPath = '/projects';
-    
-    it('should return projects if status is less than 300', async () => {
+
+    it('should return projects if status is less than 300 and not 204', async () => {
       window.fetch = jest.fn().mockImplementation(() => Promise.resolve({
         json: jest.fn(() => Promise.resolve(mockData.mockProjects)),
         status: 200
       }));
       const result = await fetchData(mockPath);
       expect(result).toEqual(mockData.mockProjects);
+    });
+
+    it('should return the status if it is 204', async () => {
+      window.fetch = jest.fn().mockImplementation(() => Promise.resolve({
+        status: 204
+      }));
+      const expected = 204;
+      const result = await fetchData(mockPath);
+      expect(result).toEqual(expected);
     });
 
     it('should throw an error if status is >= 300', async () => {

--- a/src/mockData/index.js
+++ b/src/mockData/index.js
@@ -125,4 +125,41 @@ export const mockProjectPalettes = [
       created_at: "2019-03-19T20:28:06.193Z",
       updated_at: "2019-03-19T20:28:06.193Z"
   }
-]
+];
+
+export const mockProjectsAfterDelete = [
+  {
+    "id": 1,
+    "name": "Game Time",
+    "created_at": "2019-03-23T18:13:25.614Z",
+    "updated_at": "2019-03-23T18:13:25.614Z",
+    palettes: [
+      {
+        id: 2,
+        name: "Favorites",
+        color1: "#A0DDFF",
+        color2: "#758ECD",
+        color3: "#C1CEFE",
+        color4: "#7189FF",
+        color5: "#624CAB",
+        project_id: 1,
+        created_at: "2019-03-19T20:28:06.193Z",
+        updated_at: "2019-03-19T20:28:06.193Z"
+      }
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Movie Tracker",
+    "created_at": "2019-03-23T18:13:25.631Z",
+    "updated_at": "2019-03-23T18:13:25.631Z",
+    palettes: []
+  },
+  {
+    "id": 3,
+    "name": "Trapper Keeper",
+    "created_at": "2019-03-23T18:13:25.652Z",
+    "updated_at": "2019-03-23T18:13:25.652Z",
+    palettes: []
+  }
+];

--- a/src/mockData/index.js
+++ b/src/mockData/index.js
@@ -163,3 +163,18 @@ export const mockProjectsAfterDelete = [
     palettes: []
   }
 ];
+
+export const mockProjectsAfterProjectDelete = [
+  {
+    "id": 1,
+    "name": "Game Time",
+    "created_at": "2019-03-23T18:13:25.614Z",
+    "updated_at": "2019-03-23T18:13:25.614Z"
+  },
+  {
+    "id": 3,
+    "name": "Trapper Keeper",
+    "created_at": "2019-03-23T18:13:25.652Z",
+    "updated_at": "2019-03-23T18:13:25.652Z"
+  }
+];


### PR DESCRIPTION
# Description
- adds actions to delete a project and delete a palette
- updates projectsReducer with cases for deleting a palette and a project
- adds deleteProjectThunk and deletePaletteThunk
- adds tests for all of the above
- adds snapshots for styling from previous PR
- updates fetch and fetch test to account for db returning only status of 204 when there is a successful DELETE or PUT 
List any dependencies that are required for this change:
N/A
Fixes # (issue)
Closes #22 
Closes #23 
## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Where should the reviewer start?:
Start with actions deleteProject and deletePalette, then projectsReducer, then deleteProjectThunk and deletePaletteThunk
## image or gif (optional):

## Additional information for the reviewer:
